### PR TITLE
Remove incorrect use of the term "library"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # RGB_MAL
-This is an RGB Matrix Animation Library for the Arduino built with FastLED to use with a two button interface.
+This is an RGB Matrix Animation sketch for the Arduino built with FastLED to use with a two button interface.
 
 Many example animations available online (at least most of the ones I found) are not generally useful. 
 Some are good examples of efficient ways to drive an RGB LED Matrix, but there is a fair amount of rework required.


### PR DESCRIPTION
This is a sketch, not a library, so it's incorrect to call it a "library".

This error also occurs in the repository description. That can not be fixed via a pull request but it's easily done by clicking the **Edit** button to the right of the description text shown at the top of the repository's home page:
https://github.com/Soyokaze-42/RGB_MAL
